### PR TITLE
fix: set disableTTL=true to match permissionService to openidStrategy

### DIFF
--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -313,7 +313,7 @@ const ensurePrincipalExists = async function (principal) {
       idOnTheSource: principal.idOnTheSource,
     };
 
-    const userId = await createUser(userData, true, false);
+    const userId = await createUser(userData, true, true);
     return userId.toString();
   }
 


### PR DESCRIPTION
# Pull Request Template

## Summary

`permissionService` creates oidcStrategy-users transiently in the user collection if these users are assigned permissions but do not yet exist in the user collection. They will only be fully created when they log in the first time.

However, `permissionService` creates these transient users with a TTL, like self-registered users, but unlike oidc-users. This breaks oidc-users who are normally created using `disableTTL=true`. After expiration of the TTL, such oidc-users cannot sign in any more.

The present fix adjusts the behavior of `permissionService` so it creates the transient oidc-users in the same way as `oidcStrategy` will on first log in, namely using `disableTTL=true`.

Note that if `permissionService` should ever be able to create transient users of other types, `disableTTL` for this other types must be considered independently.


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

ran unit tests

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes



Joachim Keltsch on behalf of Daimler Truck AG.
[Provider & Legal Notice | Daimler Truck](https://www.daimlertruck.com/en/provider-legal-notice)
Copyright (c) 2025 Daimler Truck AG