### PR TITLE
feat: Prompt dialog trigger icon

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -1,6 +1,6 @@
 import { memo, useRef, useMemo, useEffect, useState, useCallback } from 'react';
 import { useWatch } from 'react-hook-form';
-import { TextareaAutosize } from '@librechat/client';
+import { LightningIcon, TextareaAutosize } from '@librechat/client';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { Constants, isAssistantsEndpoint, isAgentsEndpoint } from 'librechat-data-provider';
 import {
@@ -34,6 +34,7 @@ import EditBadges from './EditBadges';
 import BadgeRow from './BadgeRow';
 import Mention from './Mention';
 import store from '~/store';
+import PromptsButtonCommand from './PromptsButtonCommand';
 
 const ChatForm = memo(({ index = 0 }: { index?: number }) => {
   const submitButtonRef = useRef<HTMLButtonElement>(null);
@@ -321,6 +322,9 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
             >
               <div className={`${isRTL ? 'mr-2' : 'ml-2'}`}>
                 <AttachFileChat conversation={conversation} disableInputs={disableInputs} />
+              </div>
+              <div className={`${isRTL ? 'mr-2' : 'ml-2'} flex w-full items-center gap-2`}>
+                <PromptsButtonCommand icon={<LightningIcon />} submitPrompt={submitPrompt} />
               </div>
               <BadgeRow
                 showEphemeralBadges={!isAgentsEndpoint(endpoint) && !isAssistantsEndpoint(endpoint)}

--- a/client/src/components/Chat/Input/PromptsButtonCommand.tsx
+++ b/client/src/components/Chat/Input/PromptsButtonCommand.tsx
@@ -1,0 +1,173 @@
+import React, { useState, useRef, useMemo, useCallback } from 'react';
+import { AutoSizer, List } from 'react-virtualized';
+import { Spinner, useCombobox } from '@librechat/client';
+import { usePromptGroupsContext } from '~/Providers';
+import { detectVariables } from '~/utils';
+import VariableDialog from '~/components/Prompts/Groups/VariableDialog';
+import MentionItem from '~/components/Chat/Input/MentionItem';
+import { useLocalize } from '~/hooks';
+import type { TPromptGroup } from 'librechat-data-provider';
+import type { PromptOption } from '~/common';
+import { TooltipAnchor } from '@librechat/client';
+
+const ROW_HEIGHT = 40;
+
+type PromptsDialogTriggerProps = {
+  icon: React.ReactNode;
+  submitPrompt: (textPrompt: string) => void;
+  buttonClassName?: string;
+};
+
+const PromptsButtonCommand: React.FC<PromptsDialogTriggerProps> = ({
+  icon,
+  submitPrompt,
+  buttonClassName = '',
+}) => {
+  const localize = useLocalize();
+  const { allPromptGroups, hasAccess } = usePromptGroupsContext();
+  const { data, isLoading } = allPromptGroups;
+
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isVariableDialogOpen, setVariableDialogOpen] = useState(false);
+  const [variableGroup, setVariableGroup] = useState<TPromptGroup | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const prompts = useMemo(() => data?.promptGroups, [data]);
+  const promptsMap = useMemo(() => data?.promptsMap, [data]);
+
+  // Use useCombobox for search/filtering, just like PromptsCommand
+  const { matches, searchValue, setSearchValue } = useCombobox({
+    value: '',
+    options: prompts ?? [],
+  });
+
+  const handleSelect = useCallback(
+    (mention?: PromptOption, e?: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!mention) return;
+      setSearchValue('');
+      setOpen(false);
+
+      const group = promptsMap?.[mention.id];
+      if (!group) return;
+
+      const hasVariables = detectVariables(group.productionPrompt?.prompt ?? '');
+      if (hasVariables) {
+        if (e && e.key === 'Tab') e.preventDefault();
+        setVariableGroup(group);
+        setVariableDialogOpen(true);
+        return;
+      } else {
+        submitPrompt(group.productionPrompt?.prompt ?? '');
+      }
+    },
+    [promptsMap, setSearchValue, submitPrompt],
+  );
+
+  const rowRenderer = ({
+    index,
+    key,
+    style,
+  }: {
+    index: number;
+    key: string;
+    style: React.CSSProperties;
+  }) => {
+    const mention = matches[index] as PromptOption;
+    return (
+      <MentionItem
+        index={index}
+        type="prompt"
+        key={key}
+        style={style}
+        onClick={() => handleSelect(mention)}
+        name={mention.label ?? ''}
+        icon={mention.icon}
+        description={mention.description}
+        isActive={index === activeIndex}
+      />
+    );
+  };
+
+  if (!hasAccess) return null;
+
+  return (
+    <>
+      <TooltipAnchor
+        render={
+          <button
+            type="button"
+            className={buttonClassName}
+            onClick={() => setOpen(true)}
+            aria-label={localize('com_agents_prompt_selection')}
+          >
+            {icon}
+          </button>
+        }
+        description={localize('com_agents_prompt_selection')}
+        id="prompts-dialog-trigger"
+      />
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="relative w-full max-w-3xl rounded-2xl bg-surface-tertiary-alt p-4 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <input
+              ref={inputRef}
+              // The user expects focus to transition to the input field when the popover is opened
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+              placeholder={localize('com_ui_command_usage_placeholder')}
+              className="mb-1 w-full border-0 bg-surface-tertiary-alt p-2 text-sm focus:outline-none dark:text-gray-200"
+              autoComplete="off"
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') setOpen(false);
+                if (e.key === 'ArrowDown') setActiveIndex((i) => (i + 1) % matches.length);
+                else if (e.key === 'ArrowUp')
+                  setActiveIndex((i) => (i - 1 + matches.length) % matches.length);
+                else if (e.key === 'Enter' || e.key === 'Tab') {
+                  if (e.key === 'Enter') e.preventDefault();
+                  handleSelect(matches[activeIndex] as PromptOption | undefined, e);
+                }
+              }}
+            />
+            <div className="max-h-40 overflow-y-auto">
+              {isLoading ? (
+                <div className="flex h-32 items-center justify-center text-text-primary">
+                  <Spinner />
+                </div>
+              ) : (
+                <AutoSizer disableHeight>
+                  {({ width }) => (
+                    <List
+                      width={width}
+                      overscanRowCount={5}
+                      rowHeight={ROW_HEIGHT}
+                      rowCount={matches.length}
+                      rowRenderer={rowRenderer}
+                      scrollToIndex={activeIndex}
+                      height={Math.min(matches.length * ROW_HEIGHT, 160)}
+                    />
+                  )}
+                </AutoSizer>
+              )}
+            </div>
+            <VariableDialog
+              open={isVariableDialogOpen}
+              onClose={() => setVariableDialogOpen(false)}
+              group={variableGroup}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default PromptsButtonCommand;

--- a/client/src/locales/ar/translation.json
+++ b/client/src/locales/ar/translation.json
@@ -18,6 +18,7 @@
   "com_agents_name_placeholder": "اختياري: اسم العميل",
   "com_agents_no_access": "ليس لديك صلاحية تعديل هذا الوكيل.",
   "com_agents_not_available": "المساعد غير متوفر",
+  "com_agents_prompt_selection": "الاختيار الفوري",
   "com_agents_search_name": "البحث عن الوكلاء بالاسم",
   "com_agents_update_error": "حدث خطأ أثناء تحديث الوكيل الخاص بك.",
   "com_assistants_actions": "إجراءات",

--- a/client/src/locales/ca/translation.json
+++ b/client/src/locales/ca/translation.json
@@ -24,6 +24,7 @@
   "com_agents_name_placeholder": "Opcional: El nom de l'agent",
   "com_agents_no_access": "No tens accés per editar aquest agent.",
   "com_agents_not_available": "Agent no disponible",
+  "com_agents_prompt_selection": "Selecció ràpida",
   "com_agents_search_name": "Cerca agents per nom",
   "com_agents_update_error": "S'ha produït un error en actualitzar el teu agent.",
   "com_assistants_action_attempt": "L'assistent vol parlar amb {{0}}",

--- a/client/src/locales/cs/translation.json
+++ b/client/src/locales/cs/translation.json
@@ -19,6 +19,7 @@
   "com_agents_name_placeholder": "Volitelné: Název agenta",
   "com_agents_no_access": "Nemáte oprávnění upravovat tohoto agenta.",
   "com_agents_not_available": "Agent není k dispozici",
+  "com_agents_prompt_selection": "Rychlý výběr",
   "com_agents_search_name": "Hledat agenty podle jména",
   "com_agents_update_error": "Při aktualizaci agenta došlo k chybě.",
   "com_assistants_action_attempt": "Asistent se chce spojit s {{0}}",

--- a/client/src/locales/da/translation.json
+++ b/client/src/locales/da/translation.json
@@ -18,6 +18,7 @@
   "com_agents_name_placeholder": "Valgfrit: Navnet på agenten",
   "com_agents_no_access": "Du har ikke adgang til at redigere denne agent.",
   "com_agents_not_available": "Agent ikke tilgængelig",
+  "com_agents_prompt_selection": "Spørg valg",
   "com_agents_search_info": "Når det er aktiveret, kan din agent søge på nettet efter opdaterede oplysninger. Kræver en gyldig API-nøgle.",
   "com_agents_search_name": "Søg agenter efter navn",
   "com_agents_update_error": "Der opstod en fejl ved opdateringen af din agent.",

--- a/client/src/locales/de/translation.json
+++ b/client/src/locales/de/translation.json
@@ -84,6 +84,7 @@
   "com_agents_no_agent_id_error": "Keine Agenten-ID gefunden. Bitte stelle sicher, dass der Agent zuerst erstellt wurde.",
   "com_agents_no_more_results": "Du hast das Ende der Ergebnisse erreicht.",
   "com_agents_not_available": "Agent nicht verfügbar",
+  "com_agents_prompt_selection": "Schnelle Auswahl",
   "com_agents_recommended": "Unsere empfohlenen Agenten",
   "com_agents_results_for": "Ergebnisse für '{{query}}'",
   "com_agents_search_aria": "Nach Agenten suchen",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -86,6 +86,7 @@
   "com_agents_no_agent_id_error": "No agent ID found. Please ensure the agent is created first.",
   "com_agents_no_more_results": "You've reached the end of the results",
   "com_agents_not_available": "Agent Not Available",
+  "com_agents_prompt_selection": "Select Prompt",
   "com_agents_recommended": "Our recommended agents",
   "com_agents_results_for": "Results for '{{query}}'",
   "com_agents_search_aria": "Search for agents",

--- a/client/src/locales/es/translation.json
+++ b/client/src/locales/es/translation.json
@@ -72,6 +72,7 @@
   "com_agents_name_placeholder": "Opcional: El nombre del agente",
   "com_agents_no_access": "No tiene acceso para editar este agente",
   "com_agents_not_available": "Agente no disponible",
+  "com_agents_prompt_selection": "Selección rápida",
   "com_agents_search_name": "Buscar agentes por nombre",
   "com_agents_update_error": "Hubo un error al actualizar su agente.",
   "com_assistants_action_attempt": "El asistente quiere hablar con {{0}}",

--- a/client/src/locales/et/translation.json
+++ b/client/src/locales/et/translation.json
@@ -18,6 +18,7 @@
   "com_agents_name_placeholder": "Valikuline: Agendi nimi",
   "com_agents_no_access": "Sul pole õigust seda agenti muuta.",
   "com_agents_not_available": "Agent pole saadaval",
+  "com_agents_prompt_selection": "Kiire valik",
   "com_agents_search_info": "Kui see on lubatud, saab sinu agent otsida veebist ajakohast teavet. Vajalik on kehtiv API võti.",
   "com_agents_search_name": "Otsi agente nime järgi",
   "com_agents_update_error": "Agendi uuendamisel tekkis viga.",

--- a/client/src/locales/fa/translation.json
+++ b/client/src/locales/fa/translation.json
@@ -18,6 +18,7 @@
   "com_agents_name_placeholder": "اختیاری: نام کارگزار",
   "com_agents_no_access": "شما به ویرایش این کارگزار دسترسی ندارید.",
   "com_agents_not_available": "کارگزار در دسترس نیست",
+  "com_agents_prompt_selection": "انتخاب سریع",
   "com_agents_search_name": "کارگزارها را با نام جستجو کنید",
   "com_agents_update_error": "هنگام به‌روزرسانی کارگزار شما خطایی روی داد.",
   "com_assistants_action_attempt": "دستیار می خواهد با {{0}} صحبت کند ",

--- a/client/src/locales/fi/translation.json
+++ b/client/src/locales/fi/translation.json
@@ -17,6 +17,7 @@
   "com_agents_no_access": "Sinulla ei ole lupaa muokata tätä agenttia.",
   "com_agents_no_agent_id_error": "Agentin tunnistetta ei löytynyt. Varmista ensin, että agentti on luotu.",
   "com_agents_not_available": "Agentti ei ole saatavilla.",
+  "com_agents_prompt_selection": "Pikavalinta",
   "com_agents_search_info": "Asetuksen ollessa päällä agentti voi tehdä verkkohakuja ajantasaisen tiedon hakemista varten. Vaatii voimassaolevan API-avaimen.",
   "com_agents_search_name": "Etsi agentteja nimen perusteella",
   "com_agents_update_error": "Agentin päivittämisessä tapahtui virhe.",

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -75,6 +75,7 @@
   "com_agents_no_agent_id_error": "Aucun identifiant (ID) d'agent trouvé. Assurez-vous que l'agent existe.",
   "com_agents_no_more_results": "Plus de résultats à afficher",
   "com_agents_not_available": "Agent non disponible",
+  "com_agents_prompt_selection": "Sélection rapide",
   "com_agents_recommended": "Nos agents recommandés",
   "com_agents_results_for": "Résultats pour '{{query}}'",
   "com_agents_search_aria": "Rechercher un agent",

--- a/client/src/locales/he/translation.json
+++ b/client/src/locales/he/translation.json
@@ -84,6 +84,7 @@
   "com_agents_no_agent_id_error": "לא נמצא מזהה סוכן. אנא ודא שהסוכן נוצר תחילה",
   "com_agents_no_more_results": "הגעת לסוף התוצאות",
   "com_agents_not_available": "הסוכן לא זמין",
+  "com_agents_prompt_selection": "בחירה מהירה",
   "com_agents_recommended": "הסוכנים המומלצים שלנו",
   "com_agents_results_for": "תוצאות עבור '{{query}}'",
   "com_agents_search_aria": "חפש סוכנים",

--- a/client/src/locales/hu/translation.json
+++ b/client/src/locales/hu/translation.json
@@ -18,6 +18,7 @@
   "com_agents_name_placeholder": "Opcionális: Az ügynök neve",
   "com_agents_no_access": "Nincs jogosultsága ennek az ügynöknek a szerkesztéséhez.",
   "com_agents_not_available": "Az ügynök nem érhető el",
+  "com_agents_prompt_selection": "Gyors kiválasztás",
   "com_agents_search_name": "Ügynökök keresése név szerint",
   "com_agents_update_error": "Hiba történt az ügynök frissítése során.",
   "com_assistants_action_attempt": "Az asszisztens beszélni akar {{0}}-val",

--- a/client/src/locales/hy/translation.json
+++ b/client/src/locales/hy/translation.json
@@ -16,6 +16,7 @@
   "com_agents_name_placeholder": "Կամընտրական: Գործակալի անունը",
   "com_agents_no_access": "Դուք իրավունք չունեք խմբագրելու այս գործակալը։",
   "com_agents_not_available": "Գործակալը հասանելի չէ",
+  "com_agents_prompt_selection": "Ընտրեք հուշում անունով կամ հրամանով",
   "com_agents_search_name": "Որոնել գործակալներին ըստ անվան",
   "com_assistants_actions": "Գործողություններ",
   "com_assistants_add_actions": "Ավելացնել գործողություններ",

--- a/client/src/locales/id/translation.json
+++ b/client/src/locales/id/translation.json
@@ -5,6 +5,7 @@
   "com_a11y_end": "AI sudah selesai membalas.",
   "com_a11y_start": "AI telah mulai membalas.",
   "com_agents_by_librechat": "oleh LibreChat",
+  "com_agents_prompt_selection": "Pilih prompt berdasarkan nama atau perintah.",
   "com_auth_already_have_account": "Sudah memiliki akun?",
   "com_auth_click": "Klik",
   "com_auth_click_here": "Klik di sini",

--- a/client/src/locales/it/translation.json
+++ b/client/src/locales/it/translation.json
@@ -73,7 +73,7 @@
   "com_agents_no_access": "Non hai l'autorizzazione per modificare questo agente.",
   "com_agents_no_agent_id_error": "Non è stato trovato alcun ID agente. Assicurarsi che l'agente sia stato prima creato.",
   "com_agents_no_more_results": "Avete raggiunto la fine dei risultati",
-  "com_agents_not_available": "Agente Non Disponibile",
+  "com_agents_prompt_selection": "Seleziona un prompt per nome o comando.",
   "com_agents_recommended": "I nostri agenti consigliati",
   "com_agents_results_for": "Risultati per '{{query}}'",
   "com_agents_search_aria": "Cerca agenti",

--- a/client/src/locales/ja/translation.json
+++ b/client/src/locales/ja/translation.json
@@ -84,6 +84,7 @@
   "com_agents_no_agent_id_error": "エージェントIDが見つかりません。エージェントが作成されていることを確認してください。",
   "com_agents_no_more_results": "結果の最後まで到達しました",
   "com_agents_not_available": "エージェントは利用できません",
+  "com_agents_prompt_selection": "名前またはコマンドでプロンプトを選択してください。",
   "com_agents_recommended": "お勧めエージェント",
   "com_agents_results_for": "「{{query}}」の結果",
   "com_agents_search_aria": "エージェントを検索",

--- a/client/src/locales/ka/translation.json
+++ b/client/src/locales/ka/translation.json
@@ -20,6 +20,7 @@
   "com_agents_no_access": "თქვენ არ გაქვთ შესაბამისი წვდომა აგენტის რედაქტირებისთვის",
   "com_agents_no_agent_id_error": "აგენტის ID ვერ მოიძებნა. გთხოვთ, დარწმუნდეთ, რომ აგენტი  შექმნილია.",
   "com_agents_not_available": "აგენტი მიუწვდომელია",
+  "com_agents_prompt_selection": "აირჩიეთ პრომპტი სახელით ან ბრძანებით.",
   "com_agents_search_name": "აგენტების ძებნა სახელით",
   "com_agents_update_error": "თქვენი აგენტის განახლებისას დაფიქსირდა შეცდომა",
   "com_assistants_action_attempt": "ასისტენტს სურს გაესაუბროს {{0}}",

--- a/client/src/locales/ko/translation.json
+++ b/client/src/locales/ko/translation.json
@@ -26,7 +26,7 @@
   "com_agents_name_placeholder": "선택 사항: 에이전트의 이름",
   "com_agents_no_access": "이 에이전트를 수정할 권한이 없습니다",
   "com_agents_no_agent_id_error": "에이전트 ID를 찾을 수 없습니다. 먼저 에이전트가 생성되었는지 확인하세요.",
-  "com_agents_not_available": "에이전트를 사용할 수 없음",
+  "com_agents_prompt_selection": "이름 또는 명령어로 프롬프트를 선택하세요.",
   "com_agents_search_info": "활성화하면 에이전트가 최신 정보를 검색할 수 있도록 허용합니다. 유효한 API 키가 필요합니다.",
   "com_agents_search_name": "이름으로 에이전트 검색",
   "com_agents_update_error": "에이전트 업데이트 중 오류가 발생했습니다",

--- a/client/src/locales/lv/translation.json
+++ b/client/src/locales/lv/translation.json
@@ -83,7 +83,7 @@
   "com_agents_no_access": "Jums nav piekļuves šī aģenta rediģēšanai.",
   "com_agents_no_agent_id_error": "Nav atrasts aģenta ID. Lūdzu, pārliecinieties, ka aģents ir izveidots.",
   "com_agents_no_more_results": "Jūs esat sasniedzis rezultātu beigas",
-  "com_agents_not_available": "Aģents nav pieejams",
+  "com_agents_prompt_selection": "Izvēlieties uzvedni pēc nosaukuma vai komandas.",
   "com_agents_recommended": "Mūsu rekomendētie aģenti",
   "com_agents_results_for": "Rezultāti par '{{query}}'",
   "com_agents_search_aria": "Meklēt aģentus",

--- a/client/src/locales/nb/translation.json
+++ b/client/src/locales/nb/translation.json
@@ -81,6 +81,7 @@
   "com_agents_no_agent_id_error": "Ingen agent-ID funnet. Sørg for at agenten er opprettet først.",
   "com_agents_no_more_results": "Du har nådd slutten av resultatene.",
   "com_agents_not_available": "Agent ikke tilgjengelig",
+  "com_agents_prompt_selection": "Velg en prompt etter navn eller kommando.",
   "com_agents_recommended": "Våre anbefalte agenter",
   "com_agents_results_for": "Resultater for «{{query}}»",
   "com_agents_search_aria": "Søk etter agenter",

--- a/client/src/locales/nl/translation.json
+++ b/client/src/locales/nl/translation.json
@@ -72,7 +72,7 @@
   "com_agents_name_placeholder": "Optioneel: De naam van de agent",
   "com_agents_no_access": "Je hebt geen toegang om deze agent te bewerken.",
   "com_agents_no_more_results": "Je bent aan het einde van de resultaten gekomen",
-  "com_agents_not_available": "Agent niet beschikbaar",
+  "com_agents_prompt_selection": "Selecteer een prompt op naam of commando.",
   "com_agents_recommended": "Onze aanbevolen agenten",
   "com_agents_results_for": "Resultaten voor '{{query}}'",
   "com_agents_search_aria": "Agenten zoeken",

--- a/client/src/locales/pl/translation.json
+++ b/client/src/locales/pl/translation.json
@@ -17,7 +17,7 @@
   "com_agents_missing_provider_model": "Wybierz dostawcę i model przed utworzeniem agenta.",
   "com_agents_name_placeholder": "Opcjonalnie: Nazwa agenta",
   "com_agents_no_access": "Nie masz zezwolenia na edycję tego agenta.",
-  "com_agents_not_available": "Agent nie jest dostępny",
+  "com_agents_prompt_selection": "Wybierz prompt według nazwy lub komendy.",
   "com_agents_search_name": "Wyszukaj agentów po nazwie",
   "com_agents_update_error": "Wystąpił błąd podczas aktualizacji agenta.",
   "com_assistants_action_attempt": "Asysten chce rozmawiać z {{0}}",

--- a/client/src/locales/pt-BR/translation.json
+++ b/client/src/locales/pt-BR/translation.json
@@ -80,6 +80,7 @@
   "com_agents_no_agent_id_error": "Nenhum ID de agente encontrado. Certifique-se de que o agente seja criado primeiro.",
   "com_agents_no_more_results": "Você chegou ao fim dos resultados",
   "com_agents_not_available": "Agente não disponível.",
+  "com_agents_prompt_selection": "Selecione um prompt pelo nome ou comando.",
   "com_agents_recommended": "Agentes recomendados",
   "com_agents_results_for": "Resultados para '{{query}}'",
   "com_agents_search_aria": "Buscar agentes",

--- a/client/src/locales/pt-PT/translation.json
+++ b/client/src/locales/pt-PT/translation.json
@@ -53,6 +53,7 @@
   "com_agents_no_agent_id_error": "Nenhum ID de Agente Encontrado. Por favor, garante que tens um agente criado.",
   "com_agents_no_more_results": "Chegou ao fim dos resultados",
   "com_agents_not_available": "Agente não disponível.",
+  "com_agents_prompt_selection": "Selecione um prompt pelo nome ou comando.",
   "com_agents_recommended": "Os nossos agentes recomendados",
   "com_agents_results_for": "Resultados para '{{query}}'",
   "com_agents_search_aria": "Pesquisar agentes",

--- a/client/src/locales/ru/translation.json
+++ b/client/src/locales/ru/translation.json
@@ -84,6 +84,7 @@
   "com_agents_no_agent_id_error": "Идентификатор агента не найден. Убедитесь, что агент сначала создан.",
   "com_agents_no_more_results": "Вы дошли до конца результатов",
   "com_agents_not_available": "Агент недоступен",
+  "com_agents_prompt_selection": "Выберите подсказку по названию или команде.",
   "com_agents_recommended": "Наши рекомендуемые агенты",
   "com_agents_results_for": "Результат для '{{query}}'",
   "com_agents_search_aria": "Поиск агентов",

--- a/client/src/locales/sv/translation.json
+++ b/client/src/locales/sv/translation.json
@@ -74,7 +74,7 @@
   "com_agents_no_access": "Du har inte behörighet att redigera den här agenten.",
   "com_agents_no_agent_id_error": "Inget agent-ID hittades. Se till att agenten skapas först.",
   "com_agents_no_more_results": "Du har nått slutet av resultaten",
-  "com_agents_not_available": "Agenten är inte tillgänglig.",
+  "com_agents_prompt_selection": "Välj en prompt efter namn eller kommando.",
   "com_agents_recommended": "Våra rekommenderade agenter",
   "com_agents_results_for": "Resultat för \"{{query}}\"",
   "com_agents_search_aria": "Sök efter agenter",

--- a/client/src/locales/th/translation.json
+++ b/client/src/locales/th/translation.json
@@ -28,7 +28,7 @@
   "com_agents_name_placeholder": "ตัวเลือกเพิ่มเติม: ชื่อของเอเจนต์",
   "com_agents_no_access": "คุณไม่มีสิทธิ์แก้ไขเอเจนต์นี้",
   "com_agents_no_agent_id_error": "ไม่พบรหัสเอเจนต์ (Agent ID) กรุณาสร้างเอเจนต์ก่อน",
-  "com_agents_not_available": "ไม่มีเอเจนต์ให้บริการ",
+  "com_agents_prompt_selection": "เลือกพรอมต์ตามชื่อหรือคำสั่ง.",
   "com_agents_search_info": "เมื่อเปิดใช้งานแล้ว เอเจนต์องคุณจะสามารถค้นหาข้อมูลล่าสุดบนเว็บได้ ต้องมีรหัส API ที่ถูกต้อง",
   "com_agents_search_name": "ค้นหาเอเจนต์ตามชื่อ",
   "com_agents_update_error": "เกิดข้อผิดพลาดในการอัปเดตเอเจนต์ของคุณ",

--- a/client/src/locales/tr/translation.json
+++ b/client/src/locales/tr/translation.json
@@ -17,7 +17,7 @@
   "com_agents_missing_provider_model": "Lütfen bir ajan oluşturmadan önce bir sağlayıcı ve model seçin.",
   "com_agents_name_placeholder": "İsteğe bağlı: Ajanın adı",
   "com_agents_no_access": "Bu ajanı düzenleme erişiminiz yok.",
-  "com_agents_not_available": "Ajan Mevcut Değil",
+  "com_agents_prompt_selection": "Komut veya ada göre bir istem seçin.",
   "com_agents_search_name": "Ajanları ada göre ara",
   "com_agents_update_error": "Ajanınız güncellenirken bir hata oluştu.",
   "com_assistants_actions": "Eylemler",

--- a/client/src/locales/uk/translation.json
+++ b/client/src/locales/uk/translation.json
@@ -81,6 +81,7 @@
   "com_agents_no_agent_id_error": "ID агента не знайдено. Переконайтеся, що агент створений.",
   "com_agents_no_more_results": "Ви переглянули всі результати",
   "com_agents_not_available": "Агент недоступний",
+  "com_agents_prompt_selection": "Виберіть підказку за назвою або командою.",
   "com_agents_recommended": "Наші рекомендовані агенти",
   "com_agents_results_for": "Результати для '{{query}}'",
   "com_agents_search_aria": "Пошук агентів",

--- a/client/src/locales/vi/translation.json
+++ b/client/src/locales/vi/translation.json
@@ -18,6 +18,7 @@
   "com_agents_name_placeholder": "Tùy chọn: Tên của agent",
   "com_agents_no_access": "Bạn không có quyền chỉnh sửa agent này.",
   "com_agents_not_available": "Agent không có sẵn",
+  "com_agents_prompt_selection": "Chọn prompt theo tên hoặc lệnh.",
   "com_agents_search_info": "Khi được bật, cho phép agent của bạn tìm kiếm thông tin mới nhất trên web. Yêu cầu khóa API hợp lệ.",
   "com_assistants_file_search": "Tìm kiếm Tập tin",
   "com_assistants_knowledge": "Kiến thức",

--- a/client/src/locales/zh-Hans/translation.json
+++ b/client/src/locales/zh-Hans/translation.json
@@ -84,6 +84,7 @@
   "com_agents_no_agent_id_error": "未找到智能体 ID，请首先确保智能体已创建。",
   "com_agents_no_more_results": "您已到达结果末尾",
   "com_agents_not_available": "智能体不可用",
+  "com_agents_prompt_selection": "按名称或命令选择提示。",
   "com_agents_recommended": "我们推荐的智能体",
   "com_agents_results_for": "'{{query}}' 的结果",
   "com_agents_search_aria": "搜索智能体",

--- a/client/src/locales/zh-Hant/translation.json
+++ b/client/src/locales/zh-Hant/translation.json
@@ -75,7 +75,7 @@
   "com_agents_name_placeholder": "選填：代理人的名稱",
   "com_agents_no_access": "您沒有權限編輯此助理",
   "com_agents_no_agent_id_error": "找不到 Agent ID。請先建立 Agent。",
-  "com_agents_not_available": "代理不可用",
+  "com_agents_prompt_selection": "請依名稱或指令選擇提示。",
   "com_agents_recommended": "我們推薦的agents",
   "com_agents_search_info": "啟用後，允許您的 Agent 搜尋網路以取得最新資訊。需要有效的 API 金鑰。",
   "com_agents_search_instructions": "輸入名稱或描述來搜尋agents",


### PR DESCRIPTION
## Summary

This feature provides to common user icon beside file attachment icon possibility to open prompt selection dialog also clicking on the icon which is represented under #11047
That way it should be intuitive to common user when hover on the icon to see tooltip with the description what this action is used for, and open prompts directly, which is not in coalision with original feature (using slash command in chat bar to open the same dialog) 

Closes #11047

## Changes

- Created PromptsButtonCommand component which includes icon (button) and corresponding actions.
- In ChatForm component change includes additional import of the aforementioned component
- Added translation key for tooltip text for the PromptsButtonCommand which appear on hover

## Change Type

Please delete any irrelevant options.

- [x] Translation update

## Testing

Just run npm run test:client for testing frontend and npm run test:api for testing backend.

### **Test Configuration**:

None to be added except to follow standard docs instructions.


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
